### PR TITLE
NSG設定をVMのNICに割り当てる

### DIFF
--- a/isucon5-qualifier/azuredeploy.json
+++ b/isucon5-qualifier/azuredeploy.json
@@ -212,7 +212,10 @@
         "dnsSettings": {
           "dnsServers": []
         },
-        "enableIPForwarding": false
+        "enableIPForwarding": false,
+        "networkSecurityGroup": {
+          "id": "[concat(resourceId('Microsoft.Network/networkSecurityGroups/', variables('commonName')))]"
+        }
       },
       "resources": [],
       "dependsOn": [
@@ -245,7 +248,10 @@
         "dnsSettings": {
           "dnsServers": []
         },
-        "enableIPForwarding": false
+        "enableIPForwarding": false,
+        "networkSecurityGroup": {
+          "id": "[concat(resourceId('Microsoft.Network/networkSecurityGroups/', variables('commonName')))]"
+        }
       },
       "resources": [],
       "dependsOn": [


### PR DESCRIPTION
NSG設定がNICにアサインされていないために、有効化されていませんでした。
せっかく設定しているので、割当して有効化するとよいと思います。

マージしていただけると下記のように自動的にNSGの設定が追加されます。

![image](https://cloud.githubusercontent.com/assets/74346/18236005/a8502a84-735c-11e6-95f3-21060656cadf.png)
